### PR TITLE
Fix Failing Crypto Tests

### DIFF
--- a/tests/Hydrogen.CryptoEx.Tests/ECDSATests.cs
+++ b/tests/Hydrogen.CryptoEx.Tests/ECDSATests.cs
@@ -63,12 +63,13 @@ public class ECDSATests {
 			throw new ArgumentException(InvalidRAndSSignature, nameof(rs));
 		}
 
-		var outStream = new MemoryStream();
-		var generator = new DerSequenceGenerator(outStream);
-		generator.AddObject(new DerInteger(rs[0]));
-		generator.AddObject(new DerInteger(rs[1]));
-		//generator.Close();
-		return outStream.ToArray();
+		using (var outputStream = new MemoryStream()) {
+			using (var sequenceGenerator = new DerSequenceGenerator(outputStream)) {
+				sequenceGenerator.AddObject(new DerInteger(rs[0]));
+				sequenceGenerator.AddObject(new DerInteger(rs[1]));
+			}
+			return outputStream.ToArray();
+		}
 	}
 
 	public static byte[] CanonicalizeSig(BigInteger order, byte[] sig) {

--- a/tests/Hydrogen.CryptoEx.Tests/Hydrogen.CryptoEx.Tests.csproj
+++ b/tests/Hydrogen.CryptoEx.Tests/Hydrogen.CryptoEx.Tests.csproj
@@ -34,4 +34,13 @@
       </EmbeddedResource>
     </ItemGroup>
 
+	<!-- In current version of BouncyCastle.Cryptography there is a problem with finding interfaces implementations. 
+	     See here https://github.com/bcgit/bc-csharp/issues/447 for more details. -->
+	<ItemGroup>
+		<PackageReference Include="BouncyCastle.Cryptography" Version="2.3.0" ExcludeAssets="Compile" GeneratePathProperty="true" />
+		<Reference Include="BouncyCastle.Cryptography">
+			<HintPath>$(PkgBouncyCastle_Cryptography)\lib\netstandard2.0\BouncyCastle.Cryptography.dll</HintPath>
+		</Reference>
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
1. `BouncyCastle` intoduced some interface breaking changes during their modernization.
I had to work around it using one of the approaches suggested [here.](https://github.com/bcgit/bc-csharp/issues/447)
 
2. `DerSequenceGenerator` from `BouncyCastle` now implements `IDisposable` so the `Close` method is no longer exposed to the consumer.